### PR TITLE
Site Refresh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ Assign a category using the `category: ` tag in your post's frontmatter.
 | `model-dev`   | More advanced topics for model developers |
 | `feature`     | Detailed documentation for various ROSS features |
 | `ross-dev`    | Advanced topics for developers working on ROSS core |
+| `announcement`| Announcements relevant to the ROSS community |
 
 By having an established set of categories, the Archives page clearly differentiates between topics for ROSS users (model developers) and topics for ROSS developers.
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,7 +18,6 @@
         <img width="19px" height="19px" src="{{ site.baseurl }}/images/github.png">
       </a>
       <a class="page-link" href="https://github.com/ross-org/ROSS/issues">Issues</a>
-      <a class="page-link" href="https://github.com/ross-org/ROSS/wiki">Wiki</a>
       <a class="page-link" href="http://ross-org.github.io/ROSS-docs/docs/html/">Doxygen</a>
       </span>
     </nav>

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -10,7 +10,7 @@ layout: default
       </div>
       <br />
       <div class="container">
-      	<h1>Latest Posts</h1>
+      	<h1>Latest Updates</h1>
 		<ul class="posts noList">
 		  {% for post in site.posts limit: 5 %}
 		    <li>

--- a/_posts/2019-09-22-site-refresh.md
+++ b/_posts/2019-09-22-site-refresh.md
@@ -1,0 +1,10 @@
+---
+title: "Website Refresh"
+date: September 22, 2019
+layout: post
+category: announcement
+---
+
+The ROSS-org website has just been refreshed.
+We hope to make it clear that this website is the starting point for [ROSS documentation](./documentation.html) and a central place for any [announcements](./annoucements.html) relevant to the ROSS community.
+We welcome any contributions, announcements or documentation posts, from the community (check out our [contributing guide](https://github.com/ROSS-org/ross-org.github.io/blob/master/CONTRIBUTING.md) for details).

--- a/about.md
+++ b/about.md
@@ -3,7 +3,7 @@ layout: page
 title: About
 ---
 
-# Overview
+## Overview
 
 ROSS is an acronym for Rensselaer's Optimistic Simulation System.
 It is a parallel discrete-event simulator that executes on multiprocessor systems and/or supercomputers.
@@ -28,7 +28,7 @@ We are investigating automatic methods that are able to generate the reverse exe
 For more information on ROSS and Reverse Computation we refer the interested reader to [1, 2].
 Both of these text are provided as additional reading in the ROSS distribution.
 
-**References**
+### References
 
 1. C. D. Carothers, K. Perumalla and R. M. Fujimoto. Efficient Parallel Simulation Using Reverse Computation. *ACM Transactions on Modeling and Computer Simulation*, vol 9. no 3. Jul. 1999.
 2. C. D. Carothers, D. Bauer and S. Pearce. High-Performance, Low Memory, Modular Time Warp System. In *Proceedings of the 14th Workshop of Parallel on Distributed Simulation* (PADS '00), pages 53&ndash;60, May 2000.
@@ -37,7 +37,11 @@ Both of these text are provided as additional reading in the ROSS distribution.
 5. D. R. Jefferson and H. Sowizral. Fast Concurrent Simulation Using the Time Warp Mechanism, Part I: Local Control. Technical Report N-1906-AF, RAND Corporation, Dec. 1982.
 6. D. R. Jefferson. Virtual Time. *ACM Transactions on Programming Languages and Systems*, vol. 7 no. 3 pp. 404&ndash;425, Jul. 1985.
 
-# History of the Code
+### Related Work
+
+Many ROSS-related publications can be found on [Professor Carother's website](https://www.cs.rpi.edu/~chrisc/).
+
+## History of the Code
 
 ROSS's history starts with a one-week re-implementation of [Georgia Tech Time Warp (GTW)](http://www.cc.gatech.edu/computing/pads/tech-parallel-gtw.html) by Shawn Pearce and Dave Bauer in 1999.
 After 10 years of in-house development, version 5.0 of [Rensselaer's Optimistic Simulation System](http://sourceforge.net/projects/pdes/) went live at SourceForge.net.

--- a/about.md
+++ b/about.md
@@ -3,6 +3,8 @@ layout: page
 title: About
 ---
 
+# Overview
+
 ROSS is an acronym for Rensselaer's Optimistic Simulation System.
 It is a parallel discrete-event simulator that executes on multiprocessor systems and/or supercomputers.
 ROSS is geared for running large-scale simulation models (millions of object models).

--- a/announcements.md
+++ b/announcements.md
@@ -1,0 +1,12 @@
+---
+layout: page
+title:  Archive
+---
+
+## Past Announcements
+
+<ul>
+{% for page in site.categories.announcement %}
+  <li><a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a></li>
+{% endfor %}
+</ul>

--- a/announcements.md
+++ b/announcements.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title:  Archive
+title:  Annoncements
 ---
 
 ## Past Announcements

--- a/archive.md
+++ b/archive.md
@@ -3,6 +3,9 @@ layout: page
 title:  Archive
 ---
 
+Most of the blog posts document ROSS features, which are organized into category here.
+See the [list of announcements](./announcements.md) for time-specific postings.
+
 ## Installation
 
 <ul>

--- a/documentation.md
+++ b/documentation.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title:  Archive
+title:  Documentation
 ---
 
 Most of the blog posts document ROSS features, which are organized into category here.

--- a/documentation.md
+++ b/documentation.md
@@ -4,7 +4,7 @@ title:  Documentation
 ---
 
 Most of the blog posts document ROSS features, which are organized into category here.
-See the [list of announcements](./announcements.md) for time-specific postings.
+See the [list of announcements](./announcements.html) for time-specific postings.
 
 ## Installation
 

--- a/index.md
+++ b/index.md
@@ -7,6 +7,6 @@ title: "ROSS: Rensselaer's Optimistic Simulation System"
 
 ROSS is an acronym for Rensselaer’s Optimistic Simulation System. It is a parallel discrete-event simulator that executes on multiprocessor systems and/or supercomputers. ROSS is geared for running large-scale simulation models (millions of object models).
 
-This site contains [documentation](https://ross-org.github.io/archive.html) for both ROSS users (aka model developers) and ROSS developers. It also contains a [brief history](https://ross-org.github.io/about.html) with links to [related publications](https://ross-org.github.io/refs.html).
+This site contains [documentation](./documentation.html) for both ROSS users (aka model developers) and ROSS developers. It also contains a [brief history](./about.html) with links to [related publications](./refs.html).
 
 If you are currently developing a ROSS model and would like to request a new feature, please create an [Issue on Github](http://github.com/ross-org/ROSS/issues).

--- a/index.md
+++ b/index.md
@@ -3,12 +3,10 @@ layout: main
 title: "ROSS: Rensselaer's Optimistic Simulation System"
 ---
 
-# Hello!
+# Welcome
 
-Welcome to the new and improved ROSS website.
-Over the next few months this site will become the go-to place to learn more about ROSS.
+ROSS is an acronym for Rensselaer’s Optimistic Simulation System. It is a parallel discrete-event simulator that executes on multiprocessor systems and/or supercomputers. ROSS is geared for running large-scale simulation models (millions of object models).
 
-Currently, the best resources for information are the [wiki articles](http://github.com/ross-org/ROSS/wiki).
-Slowly, these articles will be updated and rewritten here as blog posts.
+This site contains [documentation](https://ross-org.github.io/archive.html) for both ROSS users (aka model developers) and ROSS developers. It also contains a [brief history](https://ross-org.github.io/about.html) with links to [related publications](https://ross-org.github.io/refs.html).
 
 If you are currently developing a ROSS model and would like to request a new feature, please create an [Issue on Github](http://github.com/ross-org/ROSS/issues).

--- a/projects.md
+++ b/projects.md
@@ -1,27 +1,22 @@
 ---
 layout: page
-title: Projects
+title: "Related Projects"
 ---
 
-## Projects Using ROSS
+## Active Projects
 
-- The [CODES Project](http://press3.mcs.anl.gov/codes/)
-- [Charm++ROSS](http://charm.cs.uiuc.edu/research/ROSS)
-- [XPDES](http://xpdes.org)
+- [CODES](http://press3.mcs.anl.gov/codes/): a modeling framework for simulating HPC system architectures and subsystems.
+- [NeMo](https://github.com/markplagge/NeMo): neuromorphic hardware model.
+- [Gates](https://github.com/gonsie/gates): gate-level circuit simulation model.
 
-## ROSS Models Being Developed
+## Development Team
 
-- NeMo: neuromorphic hardware model ([GitHub](https://github.com/markplagge/NeMo))
-- Gates: gate-level circuit simulation model ([GitHub](https://github.com/gonsie/gates))
+ROSS was originally developed and continues to be lead by [Professor Chris Carothers](https://www.cs.rpi.edu/~chrisc/). The current RPI development team includes:
 
-## ROSS Core Development Team at RPI
-
-- Chris Carothers (PI)
 - Noah Wolfe
 - Mark Plagge
 
-## ROSS Alumni
-
+ROSS development has been done by a number of Chris's past students, including:
 - Shawn Pearce
 - Dave Bauer
 - Misbah Mubarak

--- a/projects.md
+++ b/projects.md
@@ -17,10 +17,7 @@ title: Projects
 ## ROSS Core Development Team at RPI
 
 - Chris Carothers (PI)
-- Elsa Gonsiorowski
-- Justin LaPre
 - Noah Wolfe
-- Caitlin Ross
 - Mark Plagge
 
 ## ROSS Alumni
@@ -28,3 +25,6 @@ title: Projects
 - Shawn Pearce
 - Dave Bauer
 - Misbah Mubarak
+- Elsa Gonsiorowski
+- Justin LaPre
+- Caitlin Ross


### PR DESCRIPTION
This update includes
- refresh of welcome text, related projects, developers
- removed references to the wiki, which I'm declaring deprecated
- added an 'announcements' page
- changed 'archive' to 'documentation' to make its purpose clear