### PR TITLE
Adding "don't mess with the msg state" faq suggestion

### DIFF
--- a/_posts/2021-12-21-usage-faq.md
+++ b/_posts/2021-12-21-usage-faq.md
@@ -221,3 +221,17 @@ A quick list of Answered Questions for new people (and not so much) to ROSS.
      are created or create several different pools for every single event type
      (challenging to support cleanly and also very inefficient - will lead to more
      problems than it solves), and so on and on.
+
+- My model produces correct results in serial mode but it glitches on optimistic mode. No,
+    it's not segfaulting. It runs, but its output is weird. The more ranks/cores I use the
+    more it fails. What is happening?
+
+    There are many possible reasons for this to be happening, but one that has made almost
+    every ROSS developer suffer is _messing with the message state_. Sometimes reverse
+    computation is not enough to reverse an LP state. You decide to encode some
+    information in the message, so that if you have to rollback you just decode the
+    information into the LP state. This is how everybody does it, and it works, but
+    there's a catch: you have to make sure to clean the state of the message/event on
+    rollbacks too. Events are not automatically cleansed on a rollback. Remember: in
+    rollbacks both the LP state and the contents of the message have to be brought to
+    their previous state.


### PR DESCRIPTION
This comes from a bug that took me quite a while to find. Chris figured it out and he said it should be somewhere in the documentation. This is the best place I could find for it. Hopefully, somebody will read the entire FAQ and realize what is happening to their code instead of spending a week trying to debug their program :)